### PR TITLE
Fix namespace wrapping in NoDeconstructForBlueprint

### DIFF
--- a/Source/Replace/NoDeconstructForBlueprint.cs
+++ b/Source/Replace/NoDeconstructForBlueprint.cs
@@ -7,7 +7,8 @@ using System.Text;
 using System.Threading.Tasks;
 using Verse;
 
-namespace Replace_Stuff.Replace;
+namespace Replace_Stuff.Replace
+{
 
 // 1.6 made a new job to specifically deconstruct for blueprints. Noooo
 // WorkGiver_ConstructDeliverResourcesToBlueprints will do it anyway! The new job, what, only is higher priority?
@@ -19,5 +20,6 @@ public static class NoDeconstructForBlueprint
 	{
 		__result = Enumerable.Empty<Thing>();
 		return false;
-	}
+        }
+}
 }


### PR DESCRIPTION
## Summary
- wrap `NoDeconstructForBlueprint` in a namespace block instead of using a file-scoped namespace

## Testing
- `dotnet build` *(fails: .NETFramework v4.7.2 reference assemblies missing)*

------
https://chatgpt.com/codex/tasks/task_e_68715789d904832bb973ce6d73082ded