### PR TITLE
Fix HarmonyPatch type array syntax

### DIFF
--- a/Source/OverMineable/CornerTouchAllowed.cs
+++ b/Source/OverMineable/CornerTouchAllowed.cs
@@ -65,7 +65,7 @@ namespace Replace_Stuff.OverMineable
 
 
 	//Make sure mineable drop is in miner's region so it's not blocked off 
-	[HarmonyPatch(typeof(Mineable), "TrySpawnYield", [typeof(Map), typeof(bool), typeof(Pawn)])]
+        [HarmonyPatch(typeof(Mineable), "TrySpawnYield", new Type[] { typeof(Map), typeof(bool), typeof(Pawn) })]
 	public static class DropOnPawn
 	{
 		//private void TrySpawnYield(Map map, float yieldChance, bool moteOnWaste, Pawn pawn)

--- a/Source/OverMineable/DeliverUnderRock.cs
+++ b/Source/OverMineable/DeliverUnderRock.cs
@@ -14,7 +14,7 @@ namespace Replace_Stuff.OverMineable
 {
 
 	// In CanConstruct, skip FirstBlockingThing if it's just a haul job
-	[HarmonyPatch(typeof(GenConstruct), nameof(GenConstruct.CanConstruct), [typeof(Thing), typeof(Pawn), typeof(bool), typeof(bool), typeof(JobDef)])]
+        [HarmonyPatch(typeof(GenConstruct), nameof(GenConstruct.CanConstruct), new Type[] { typeof(Thing), typeof(Pawn), typeof(bool), typeof(bool), typeof(JobDef) })]
 	public static class DeliverUnderRock
 	{
 		//public static bool CanConstruct(Thing t, Pawn p, bool checkSkills = true, bool forced = false, JobDef jobForReservation = null)

--- a/Source/Replace/NoWallAttachment.cs
+++ b/Source/Replace/NoWallAttachment.cs
@@ -12,7 +12,7 @@ using Verse;
 
 namespace Replace_Stuff
 {
-	[HarmonyPatch(typeof(GenConstruct), nameof(GenConstruct.GetWallAttachedTo), [typeof(IntVec3), typeof(Rot4), typeof(Map)])]
+        [HarmonyPatch(typeof(GenConstruct), nameof(GenConstruct.GetWallAttachedTo), new Type[] { typeof(IntVec3), typeof(Rot4), typeof(Map) })]
 	public static class NoWallAttachment
 	{
 		//public static Thing GetWallAttachedTo(IntVec3 pos, Rot4 rot, Map map)


### PR DESCRIPTION
## Summary
- fix HarmonyPatch attributes to use `new Type[]` for parameter arrays

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687158746fb0832ba1d6a17c9956ea03