### PR TITLE
Fix emptyList declaration

### DIFF
--- a/Source/Replace/NoWallAttachment.cs
+++ b/Source/Replace/NoWallAttachment.cs
@@ -56,7 +56,7 @@ namespace Replace_Stuff
 	[HarmonyPatch(typeof(GenConstruct), nameof(GenConstruct.GetAttachedBuildings))]
 	public static class NoAttachedBuildings
 	{
-		private static List<Thing> emptyList = [];
+                private static readonly List<Thing> emptyList = new List<Thing>();
 
 		//public static List<Thing> GetAttachedBuildings(Thing thing)
 		public static bool Prefix(Thing thing, ref List<Thing> __result)


### PR DESCRIPTION
## Summary
- fix `emptyList` declaration in `NoWallAttachment.cs`

## Testing
- `dotnet build 'Replace Stuff.sln' -c Release` *(fails: `command not found: dotnet`)*

------
https://chatgpt.com/codex/tasks/task_e_68717f269598832b9fcfaf0e0960fcdc