### PR TITLE
Fix translation key for replacement progress

### DIFF
--- a/Languages/English/Keyed/AutoEnglish.xml
+++ b/Languages/English/Keyed/AutoEnglish.xml
@@ -14,6 +14,6 @@
 	<TD.FailedStuffBeingReplaced>stuff being replaced</TD.FailedStuffBeingReplaced>
 	<TD.SettingsPreferredBridge>Preferred Bridge order to place when needed:</TD.SettingsPreferredBridge>
 	<TD.SettingsBridgeResources>(First priority is bridges you have resources for ; Second priority is this list order - drag-and-drop to re-order)</TD.SettingsBridgeResources>
-	<TD.ReplacementAlreadyInProgess>Replacement already in progess.</TD.ReplacementAlreadyInProgess>
+       <TD.ReplacementAlreadyInProgress>Replacement already in progress.</TD.ReplacementAlreadyInProgress>
 	
 </LanguageData>

--- a/Languages/Japanese/Keyed/AutoEnglish.xml
+++ b/Languages/Japanese/Keyed/AutoEnglish.xml
@@ -14,6 +14,6 @@
   <TD.FailedStuffBeingReplaced>材料が置き換えられました</TD.FailedStuffBeingReplaced>
   <TD.SettingsPreferredBridge>必要に応じて設置する橋の優先順位:</TD.SettingsPreferredBridge>
   <TD.SettingsBridgeResources>(優先順位第一は資源がある橋;優先順位第二はこのリストの順位です-ドラッグアンドドロップで並べ替え)</TD.SettingsBridgeResources>
-  <TD.ReplacementAlreadyInProgess>建て替えはすでに実行中です.</TD.ReplacementAlreadyInProgess>
+  <TD.ReplacementAlreadyInProgress>建て替えはすでに実行中です.</TD.ReplacementAlreadyInProgress>
 
 </LanguageData>


### PR DESCRIPTION
## Summary
- fix `TD.ReplacementAlreadyInProgess` typo in English and Japanese translations

## Testing
- `grep -R ReplacementAlreadyInProgess -n | wc -l`
- `grep -R ReplacementAlreadyInProgress -n | wc -l`
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687185ff4f34832bb4a937f5f282c544